### PR TITLE
Fixes for s3-sync action

### DIFF
--- a/.github/workflows/s3-sync-dev.yaml
+++ b/.github/workflows/s3-sync-dev.yaml
@@ -1,9 +1,10 @@
-name: Upload Cloud Formation
+name: Upload Cloud Formation - Dev
 
 on:
   push:
     branches:
-    - dev
+    - '**'
+    - '!stable'
 
 jobs:
   deploy:
@@ -18,4 +19,5 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_REGION: 'us-east-2'   # optional: defaults to us-east-1
-        SOURCE_DIR: 'cfn/hd-notebooks-cfn.yaml'      # optional: defaults to entire repository
+        SOURCE_DIR: 'cfn'      # optional: defaults to entire repository
+        DEST_DIR: 'deployment/dev'

--- a/.github/workflows/s3-sync-dev.yaml
+++ b/.github/workflows/s3-sync-dev.yaml
@@ -20,4 +20,4 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_REGION: 'us-east-2'   # optional: defaults to us-east-1
         SOURCE_DIR: 'cfn'      # optional: defaults to entire repository
-        DEST_DIR: 'deployment/dev'
+        DEST_DIR: 'deployment/dev/${GITHUB_REF##*/}'

--- a/.github/workflows/s3-sync-stable.yaml
+++ b/.github/workflows/s3-sync-stable.yaml
@@ -1,0 +1,22 @@
+name: Upload Cloud Formation - Stable
+
+on:
+  push:
+    branches:
+    - stable
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: jakejarvis/s3-sync-action@master
+      with:
+        args: --acl public-read --follow-symlinks --delete
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: 'us-east-2'   # optional: defaults to us-east-1
+        SOURCE_DIR: 'cfn'      # optional: defaults to entire repository
+        DEST_DIR: 'deployment/latest'


### PR DESCRIPTION
Split s3-sync.yaml out into dev and stable actions. Dev will run on any branch pull that is not stable.

Added DEST_DIR so the sync uploads to 'deployment/latest' for stable and 'deployment/dev' for dev. Otherwise it would upload to the root directory of the bucket.

Should address #24