### PR TITLE
Apply fixes to resolve firefly startup failure

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,6 +27,6 @@ k3d kubeconfig merge -d firefly
 # TODO: add check for helm binary. Must be v3 or better.
 echo "Installing firefly stack..."
 kubectl create namespace ${FIREFLY_NAMESPACE}
-helm install --namespace ${FIREFLY_NAMESPACE} firefly ./helm/firefly
+helm install --namespace ${FIREFLY_NAMESPACE} firefly /home/ec2-user/charts/charts/firefly --set nginx-ingress-controller.enabled=true
 cd $WORKDIR
 echo "JupyterHub should be available at http://localhost:8090"

--- a/cfn/hd-notebooks-cfn.yaml
+++ b/cfn/hd-notebooks-cfn.yaml
@@ -165,7 +165,9 @@ Resources:
               content: !Sub |
                 #!/bin/bash -xe
                 git clone -b ${ReleaseBranch} https://github.com/gohypergiant/firefly.git /home/ec2-user/firefly
+                git clone -b ${ReleaseBranch} https://github.com/gohypergiant/charts.git /home/ec2-user/charts
                 chown -R ec2-user:ec2-user /home/ec2-user/firefly
+                chown -R ec2-user:ec2-user /home/ec2-user/charts
               mode: "000500"
               owner: "root"
               group: "root"

--- a/cfn/hd-notebooks-cfn.yaml
+++ b/cfn/hd-notebooks-cfn.yaml
@@ -22,7 +22,7 @@ Parameters:
     Description: Select a release branch to deploy.
     Type: String
     Default: stable
-    AllowedValues: [stable, dev]
+    AllowedValues: [stable, develop]
     ConstraintDescription: Must be a valid release branch
   HostnameWithDomain:
     Description: FQDN that will be used to access Firefly. Must match the certificate and the zone specified.


### PR DESCRIPTION
Firefly wasn't starting when the EC2 instance deployed via CloudFormation.
This was due to the firefly helm chart removal in the previous commit to stable.
Resolved by updating the bootstrap.sh command to clone the chart repo and run helm from that repo.
Confirmed successful CloudFormation deployment.